### PR TITLE
Remove inline styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2022-11-14
+* Block `choice_widget_dropdown`: Removed inline-styles and added it to docs
+
 ### 2022-10-04
 * Block `form_widget_simple`: Don't add anything new to hidden fields, so they don't take space in DOM
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,15 @@ Render it inside a form:
 
 ![Dropdown with ChoiceType](doc/images/choice_type_dropdown.png)
 
+Add this styling if you need a scrollbar on your dropdowns
+
+```css
+.dropdown-content {
+  max-height: 25rem;
+  overflow-y: auto;
+}
+```
+
 ## Sources
 
 Have a look at the following websites and their documentation for more information about this subject.

--- a/views/Form/bulma_layout.html.twig
+++ b/views/Form/bulma_layout.html.twig
@@ -87,7 +87,7 @@
             {%- endif -%}
         </button>
     </div>
-    <div class="dropdown-menu" id="dropdown-menu" role="menu" style="max-height: 13rem; overflow-y: auto; width: 15rem;">
+    <div class="dropdown-menu" id="dropdown-menu" role="menu">
         <div class="dropdown-content">
             {%- if placeholder is not none -%}
                 <div class="dropdown-item">


### PR DESCRIPTION
This PR removes all inline styles in the theme template.
The docs are updated with a recommended styling to use in some extension files for Bulma when using the `choice_widget_dropdown`.